### PR TITLE
Update mainnet manifest

### DIFF
--- a/tasks/mainnet-manifest.json
+++ b/tasks/mainnet-manifest.json
@@ -1,8 +1,8 @@
 {
   "Pause": false,
-  "ProtocolVersion": 5,
+  "ProtocolVersion": 7,
   "InitialInstance": 0,
-  "BootstrapEpoch": 5000000,
+  "BootstrapEpoch": 4920480,
   "NetworkName": "filecoin",
   "ExplicitPower": null,
   "IgnoreECPower": false,
@@ -12,9 +12,9 @@
   "Gpbft": {
     "Delta": 6000000000,
     "DeltaBackOffExponent": 2,
-    "QualityDeltaMultiplier": 1,
+    "QualityDeltaMultiplier": 8,
     "MaxLookaheadRounds": 5,
-    "ChainProposedLength": 100,
+    "ChainProposedLength": 20,
     "RebroadcastBackoffBase": 6000000000,
     "RebroadcastBackoffExponent": 1.3,
     "RebroadcastBackoffSpread": 0.1,
@@ -34,7 +34,7 @@
       6.27,
       7.5
     ],
-    "HeadLookback": 0,
+    "HeadLookback": 4,
     "Finalize": true
   },
   "CertificateExchange": {
@@ -44,15 +44,27 @@
     "MaximumPollInterval": 120000000000
   },
   "PubSub": {
-    "CompressionEnabled": false
+    "CompressionEnabled": true,
+    "ChainCompressionEnabled": true,
+    "GMessageSubscriptionBufferSize": 768,
+    "ValidatedMessageBufferSize": 1024
   },
   "ChainExchange": {
-    "SubscriptionBufferSize": 32,
-    "MaxChainLength": 100,
+    "SubscriptionBufferSize": 64,
+    "MaxChainLength": 20,
     "MaxInstanceLookahead": 10,
     "MaxDiscoveredChainsPerInstance": 1000,
     "MaxWantedChainsPerInstance": 1000,
     "RebroadcastInterval": 2000000000,
-    "MaxTimestampAge": 8000000000
+    "MaxTimestampAge": 16000000000
+  },
+  "PartialMessageManager": {
+    "PendingDiscoveredChainsBufferSize": 100,
+    "PendingPartialMessagesBufferSize": 100,
+    "PendingChainBroadcastsBufferSize": 100,
+    "PendingInstanceRemovalBufferSize": 10,
+    "CompletedMessagesBufferSize": 100,
+    "MaxBufferedMessagesPerInstance": 25000,
+    "MaxCachedValidatedMessagesPerInstance": 25000
   }
 }


### PR DESCRIPTION
Part of #22

Activation: Tuesday, 2025-04-29, 10:00 UTC (epoch 4920480).

Parameters adjusted vs default:
- `Gpbft.QualityDeltaMultiplier`: 1 -> 8
- `Gpbft.ChainProposedLength`: 100 -> 20
- `ChainExchange.MaxChainLength`: 100 -> 20 (required due to manifest validation rule)
- `Gpbft.HeadLookback`: 0 -> 4
- PubSub compression: disabled -> enabled
- Pubsub queue sizes:
  - GMessage:  128 -> 768
  - Validated: 128 -> 1024
- `ChainExchange.SubscriptionBufferSize`: 32 -> 64
- `ChainExchange.MaxTimestampAge`: 8s -> 16s
